### PR TITLE
Create functionality for scanning SVN commits

### DIFF
--- a/ci_secrets/main.py
+++ b/ci_secrets/main.py
@@ -1,9 +1,13 @@
 import argparse
 import logging
 from git import Repo
+import svn.remote
+import svn.local
 import detect_secrets.plugins
 import yaml
 import pkgutil
+import pathlib
+import re
 
 logging.basicConfig(format='%(asctime)s %(message)s',level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -11,7 +15,7 @@ logger = logging.getLogger(__name__)
 def main():
 	logger.debug("Hello")	
 	with open(".ci_secrets.yml", 'r') as ymlfile:
-		cfg = yaml.load(ymlfile)
+		cfg = yaml.safe_load(ymlfile)
 	if 'log_level' in cfg.keys():
 		set_log_level(cfg['log_level'])
 	plugin_types = _get_plugins(cfg['plugins'].keys())
@@ -29,6 +33,7 @@ def main():
 	parser.add_argument("--log", dest="log_level")
 	parser.add_argument("--includeDelete", action="store_true", dest="include_delete")
 	parser.add_argument("--includesMergeCommit", action="store_true", dest="includes_merge_commit")
+	parser.add_argument("--svn", action="store_true", dest="use_svn")
 	args = parser.parse_args()
 	set_log_level(args.log_level)
 	if args.since_commit is None:
@@ -38,7 +43,26 @@ def main():
 		logger.warn("0000000000000000000000000000000000000000 is an invalid commit. Is this a new branch?")
 		logger.warn("Assuming the new branch is only 1 commit ahead. This scan may miss credentials.")
 		# Assume this is a new branch and make a best guess that it's only a single commit ahead.
-		args.since_commit = "HEAD^"
+		if args.use_svn:
+			args.since_commit = 1
+		else:
+			args.since_commit = "HEAD^"
+	finding_count = 0
+	
+	if args.use_svn:
+		finding_count = scan_svn(args, plugins)
+	else:
+		finding_count = scan_git(args, plugins)
+	
+	print("Found {count} total findings.".format(count=finding_count))
+	if finding_count > 0:
+		return 1
+	return 0
+	
+def scan_git(args, plugins):
+	logger.info("Using git as default SCM")
+	finding_count = 0
+	continue_scanning = True
 	repo = Repo(args.path)
 	commit = repo.head.commit
 	common_ancestors = set(repo.merge_base(commit, args.since_commit, "--all"))
@@ -49,8 +73,6 @@ def main():
 	if commit in common_ancestors:
 		logger.warn(args.since_commit+" is not an ancestor of itself.")
 		return 0
-	finding_count = 0
-	continue_scanning = True
 	while continue_scanning:
 		finding_count += check_commit_for_secrets(commit, args.include_delete, plugins)
 		continue_scanning = set(commit.parents).isdisjoint(common_ancestors)
@@ -62,10 +84,31 @@ def main():
 			continue_scanning = True
 		else:
 			commit = commit.parents[0]
-	print("Found {count} total findings.".format(count=finding_count))
-	if finding_count > 0:
-		return 1
-	return 0
+	return finding_count
+	
+def scan_svn(args, plugins):
+	logger.info("Using svn as SCM")
+	finding_count = 0
+	svn_local = pathlib.Path().resolve()
+	commit = args.since_commit
+	svn_repo = svn.local.LocalClient(svn_local)
+	logger.debug(svn_repo.info())
+	try:
+		prev_commit = max(0,int(commit)-1)
+		svn_diff = svn_repo.diff(commit, str(prev_commit))
+	except:
+		raise ValueError('Could not get diff for commit: %s' % args.since_commit)
+	files = svn_diff.keys()
+	for f in files:
+		for h in svn_diff[f]['hunks']:
+			# GET EACH LINE FROM THE HUNK
+			# ADDITIONS ARE DENOTED BY '\n-{new addition}'
+			# REMOVALS ARE DENOTED BY '\n+{removed text}'
+			# IGNORE REMOVALS AND ONLY FOCUS ON ADDITIONS
+			lines = matches = re.findall(r'(?<=\n)-.*', h['body'])
+			for line in lines:
+				finding_count += _scan_svn_string(line, plugins, f)
+	return finding_count
 
 def check_commit_for_secrets(commit, include_delete, plugins):
 	logger.info(("*"*20)+commit.hexsha+("*"*20))
@@ -87,9 +130,19 @@ def _scan_string(line, plugins, commit_sha):
 	logger.debug("LINE: "+line)
 	finding_count = 0
 	for plugin in plugins:
-		results = plugin.analyze_string(line,0,'does not matter')
+		results = plugin.analyze_string(line)
 		for result in results:
-			print("{type} ({hash}) at commit {commit}".format(type=result.type,hash=result.secret_hash,commit=commit_sha))
+			print("{type} at commit {commit}".format(type=result,commit=commit_sha))
+			finding_count += 1
+	return finding_count
+	
+def _scan_svn_string(line, plugins, filename):
+	finding_count = 0
+	for plugin in plugins:
+		results = plugin.analyze_string(line)
+		for result in results:
+			masked = '*' * len(result)
+			print("{type} at file {f}".format(type=masked,f=filename))
 			finding_count += 1
 	return finding_count
 

--- a/example.travis.yml
+++ b/example.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+    - "3.8"
 before_install:
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+GitPython==3.1.43
+detect-secrets==1.5.0
+urllib3==1.26.6
+svn==1.0.1
+packaging==22.0


### PR DESCRIPTION
Changes:

- Updated yaml.load() to yaml.safe_load() since yaml.load() without specifying a Loader is deprecated
- Added parser argument '--svn' to indicate in CI yaml file whether it knows to scan for SVN commits. If this is not provided, it will default to scanning for git commits
-  Separated the scanning function into one for git and one for svn. This is because git and svn are parsed differently and needed separate logic in order to properly get each diff.
- svn scanning uses the CI's working directory (pathlib.Path().resolve()) to create a local client. This allows us to create a diff between the current and previous commit. The diff object is separated by each file that has been changed and includes 'hunks' or sections of code that has been updated since the last commit.